### PR TITLE
perf: add getTasksByDonor/getTasksByRequester to eliminate profile page table scan

### DIFF
--- a/app/profile/[user]/page.tsx
+++ b/app/profile/[user]/page.tsx
@@ -300,17 +300,14 @@ export default async function ProfilePage({
   const profile = await service.getProfile(user)
   if (!profile) notFound()
 
-  // Fetch all tasks to derive contributions and requests
-  const allTasksResult = await service.getTasks({ page: 1, per_page: 100 })
-  const allTasks = allTasksResult.data
+  // Fetch only the tasks relevant to this user — avoids a full table scan
+  const [donorResult, requesterResult] = await Promise.all([
+    service.getTasksByDonor(profile.id),
+    service.getTasksByRequester(profile.id),
+  ])
 
-  // Tasks completed by this user (claimed_by + status=completed)
-  const completedTasks = allTasks.filter(
-    (t) => t.claimed_by === profile.id && t.status === 'completed',
-  )
-
-  // Tasks requested by this user
-  const requestedTasks = allTasks.filter((t) => t.requester_id === profile.id)
+  const completedTasks = donorResult.data
+  const requestedTasks = requesterResult.data
 
   // Build synthetic completions to fill up to profile.tasks_completed count
   const completions = buildMockCompletions(profile.id, completedTasks)

--- a/app/profile/[user]/page.tsx
+++ b/app/profile/[user]/page.tsx
@@ -300,10 +300,11 @@ export default async function ProfilePage({
   const profile = await service.getProfile(user)
   if (!profile) notFound()
 
-  // Fetch only the tasks relevant to this user — avoids a full table scan
+  // Scoped to this user's tasks; real DB would use an indexed query.
+  // per_page:1000 ensures users with many tasks are not truncated.
   const [donorResult, requesterResult] = await Promise.all([
-    service.getTasksByDonor(profile.id),
-    service.getTasksByRequester(profile.id),
+    service.getTasksByDonor(profile.id, { per_page: 1000 }),
+    service.getTasksByRequester(profile.id, { per_page: 1000 }),
   ])
 
   const completedTasks = donorResult.data

--- a/lib/services/data-service.ts
+++ b/lib/services/data-service.ts
@@ -11,8 +11,14 @@ import type {
 import type { CompleteTaskInput, TaskFilterInput } from '@/lib/schemas'
 
 // ---------------------------------------------------------------------------
-// Shared result shapes
+// Shared param / result shapes
 // ---------------------------------------------------------------------------
+
+/** Subset of TaskFilterInput used when a query is already scoped by user. */
+export interface PaginationParams {
+  page?: number
+  per_page?: number
+}
 
 export interface PaginatedResult<T> {
   data: T[]
@@ -43,6 +49,10 @@ export interface DataService {
   // Tasks
   getTasks(filters?: TaskFilterInput): Promise<PaginatedResult<Task>>
   getTask(id: string): Promise<Task | null>
+  /** Returns tasks where `claimed_by === userId` and `status === 'completed'`. */
+  getTasksByDonor(userId: string, params?: PaginationParams): Promise<PaginatedResult<Task>>
+  /** Returns tasks where `requester_id === userId`. */
+  getTasksByRequester(userId: string, params?: PaginationParams): Promise<PaginatedResult<Task>>
   createTask(
     data: { github_issue_url: string; template_id: string },
     userId: string,

--- a/lib/services/mock-data-service.ts
+++ b/lib/services/mock-data-service.ts
@@ -21,6 +21,7 @@ import {
 import type {
   DataService,
   PaginatedResult,
+  PaginationParams,
   ClaimResult,
   CompleteResult,
 } from './data-service'
@@ -634,6 +635,54 @@ export class MockDataService implements DataService {
 
   async getTask(id: string): Promise<Task | null> {
     return this.store.tasks.get(id) ?? null
+  }
+
+  async getTasksByDonor(
+    userId: string,
+    params?: PaginationParams,
+  ): Promise<PaginatedResult<Task>> {
+    const page = params?.page ?? 1
+    const perPage = params?.per_page ?? 20
+
+    const results = Array.from(this.store.tasks.values()).filter(
+      (t) => t.claimed_by === userId && t.status === 'completed',
+    )
+
+    // Sort newest completion first
+    results.sort(
+      (a, b) =>
+        new Date(b.completed_at ?? b.updated_at).getTime() -
+        new Date(a.completed_at ?? a.updated_at).getTime(),
+    )
+
+    const total = results.length
+    const offset = (page - 1) * perPage
+    const data = results.slice(offset, offset + perPage)
+
+    return { data, total, page, per_page: perPage, has_more: offset + data.length < total }
+  }
+
+  async getTasksByRequester(
+    userId: string,
+    params?: PaginationParams,
+  ): Promise<PaginatedResult<Task>> {
+    const page = params?.page ?? 1
+    const perPage = params?.per_page ?? 20
+
+    const results = Array.from(this.store.tasks.values()).filter(
+      (t) => t.requester_id === userId,
+    )
+
+    // Sort newest first
+    results.sort(
+      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+    )
+
+    const total = results.length
+    const offset = (page - 1) * perPage
+    const data = results.slice(offset, offset + perPage)
+
+    return { data, total, page, per_page: perPage, has_more: offset + data.length < total }
   }
 
   async createTask(


### PR DESCRIPTION
## Summary

- Adds `PaginationParams` interface to `DataService` for scoped query methods
- Adds `getTasksByDonor(userId, params?)` and `getTasksByRequester(userId, params?)` to the `DataService` interface and `MockDataService` implementation
- Updates `app/profile/[user]/page.tsx` to call these two methods in parallel via `Promise.all` instead of fetching all tasks with `per_page: 100` and filtering in memory

## Motivation

The profile page was doing a full table scan (`getTasks({ page: 1, per_page: 100 })`) and then filtering results in memory twice — once for donor tasks and once for requester tasks. When backed by a real database, this scales with the total task count rather than the per-user count. The new scoped methods encapsulate the filter so the real DB implementation can use indexed queries on `claimed_by` and `requester_id`.

## Test plan

- [x] `npm run build` — zero type errors, zero lint errors
- [x] `npm test` — 230 tests pass
- [ ] Visual check: visit `/profile/sarah-chen` — contributions and requested tabs should render identically to before

Closes #11