### PR TITLE
fix: validate external API fetch responses with Zod schemas

### DIFF
--- a/app/api/webhooks/github/route.ts
+++ b/app/api/webhooks/github/route.ts
@@ -5,16 +5,16 @@ import { NextRequest, NextResponse } from 'next/server'
 //
 // Receives GitHub webhook events (push, pull_request, etc.).
 //
-// STUB: Currently logs the event and returns 200. In production this should:
+// STUB: Currently returns 200. In production this should:
 //   1. Verify the X-Hub-Signature-256 HMAC header using WEBHOOK_SECRET.
 //   2. Parse pull_request "closed" events where merged=true and update the
 //      corresponding Task's pr_merged/pr_closed fields via DataService.
 // ---------------------------------------------------------------------------
 export async function POST(request: NextRequest) {
   try {
-    const signature = request.headers.get('x-hub-signature-256')
-    const eventType = request.headers.get('x-github-event')
-    const deliveryId = request.headers.get('x-github-delivery')
+    const _signature = request.headers.get('x-hub-signature-256')
+    const _eventType = request.headers.get('x-github-event')
+    const _deliveryId = request.headers.get('x-github-delivery')
 
     // TODO: verify HMAC signature before processing in production
     // const secret = process.env.GITHUB_WEBHOOK_SECRET

--- a/lib/github/client.ts
+++ b/lib/github/client.ts
@@ -1,49 +1,23 @@
+import { z } from 'zod'
+import {
+  GitHubRepoSchema,
+  GitHubIssueRawSchema,
+  GitHubFileContentSchema,
+  GitHubPRSchema,
+  GitHubRootTreeSchema,
+  GitHubLanguagesSchema,
+} from './schemas'
+
 const GITHUB_API = 'https://api.github.com'
 
 // ---------------------------------------------------------------------------
-// Types
+// Types — derived from schemas to avoid duplication
 // ---------------------------------------------------------------------------
 
-export interface GitHubRepo {
-  full_name: string
-  name: string
-  owner: { login: string }
-  description: string | null
-  language: string | null
-  default_branch: string
-  stargazers_count: number
-  size: number
-  topics: string[]
-  open_issues_count: number
-  html_url: string
-}
-
-export interface GitHubIssueRaw {
-  number: number
-  title: string
-  body: string | null
-  state: string
-  labels: Array<{ name: string }>
-  created_at: string
-  updated_at: string
-  html_url: string
-}
-
-export interface GitHubFileContent {
-  content: string // base64 encoded
-  encoding: string
-  size: number
-}
-
-export interface GitHubPR {
-  number: number
-  html_url: string
-  draft: boolean
-  state: string
-  user: { login: string }
-  body: string | null
-  head: { repo: { full_name: string } }
-}
+export type GitHubRepo = z.infer<typeof GitHubRepoSchema>
+export type GitHubIssueRaw = z.infer<typeof GitHubIssueRawSchema>
+export type GitHubFileContent = z.infer<typeof GitHubFileContentSchema>
+export type GitHubPR = z.infer<typeof GitHubPRSchema>
 
 // ---------------------------------------------------------------------------
 // Auth / headers
@@ -60,7 +34,7 @@ function getGitHubHeaders(): HeadersInit {
 }
 
 // ---------------------------------------------------------------------------
-// Core fetch helper
+// Core fetch helpers
 // ---------------------------------------------------------------------------
 
 async function githubFetch(path: string): Promise<Response> {
@@ -69,18 +43,11 @@ async function githubFetch(path: string): Promise<Response> {
 }
 
 /**
- * Parse the JSON body of a Response into a typed value.
- * Uses JSON.parse (returns `any`) so TypeScript allows assignment to T
- * without a type assertion.
+ * Fetch JSON from the GitHub API and validate the response shape with a Zod
+ * schema.  Throws if the request fails or if the response does not conform to
+ * the schema.
  */
-async function parseJson<T>(res: Response): Promise<T> {
-  const text = await res.text()
-  // JSON.parse returns `any`, which TypeScript allows to be assigned to T
-  // without a type assertion, keeping the assertionStyle:"never" rule happy.
-  return JSON.parse(text)
-}
-
-async function githubFetchJson<T>(path: string): Promise<T> {
+async function githubFetchJson<T>(path: string, schema: z.ZodType<T>): Promise<T> {
   const res = await githubFetch(path)
 
   if (!res.ok) {
@@ -90,7 +57,8 @@ async function githubFetchJson<T>(path: string): Promise<T> {
     )
   }
 
-  return parseJson<T>(res)
+  // JSON.parse returns `any`; schema.parse validates and narrows to T.
+  return schema.parse(JSON.parse(await res.text()))
 }
 
 // ---------------------------------------------------------------------------
@@ -101,7 +69,7 @@ async function githubFetchJson<T>(path: string): Promise<T> {
  * Fetch repository metadata.
  */
 export async function fetchRepo(owner: string, repo: string): Promise<GitHubRepo> {
-  return githubFetchJson<GitHubRepo>(`/repos/${owner}/${repo}`)
+  return githubFetchJson(`/repos/${owner}/${repo}`, GitHubRepoSchema)
 }
 
 /**
@@ -112,7 +80,10 @@ export async function fetchIssue(
   repo: string,
   issueNumber: number
 ): Promise<GitHubIssueRaw> {
-  return githubFetchJson<GitHubIssueRaw>(`/repos/${owner}/${repo}/issues/${issueNumber}`)
+  return githubFetchJson(
+    `/repos/${owner}/${repo}/issues/${issueNumber}`,
+    GitHubIssueRawSchema
+  )
 }
 
 /**
@@ -122,7 +93,7 @@ export async function fetchLanguages(
   owner: string,
   repo: string
 ): Promise<Record<string, number>> {
-  return githubFetchJson<Record<string, number>>(`/repos/${owner}/${repo}/languages`)
+  return githubFetchJson(`/repos/${owner}/${repo}/languages`, GitHubLanguagesSchema)
 }
 
 /**
@@ -144,7 +115,7 @@ export async function fetchFileContent(
     )
   }
 
-  return parseJson<GitHubFileContent>(res)
+  return GitHubFileContentSchema.parse(JSON.parse(await res.text()))
 }
 
 /**
@@ -152,8 +123,9 @@ export async function fetchFileContent(
  * Returns only the entry names (not full paths).
  */
 export async function fetchRootTree(owner: string, repo: string): Promise<string[]> {
-  const data = await githubFetchJson<{ tree: Array<{ path: string; type: string }> }>(
-    `/repos/${owner}/${repo}/git/trees/HEAD?recursive=0`
+  const data = await githubFetchJson(
+    `/repos/${owner}/${repo}/git/trees/HEAD?recursive=0`,
+    GitHubRootTreeSchema
   )
   return data.tree
     .filter((entry) => entry.type === 'blob' || entry.type === 'tree')
@@ -179,5 +151,5 @@ export async function fetchPR(
     )
   }
 
-  return parseJson<GitHubPR>(res)
+  return GitHubPRSchema.parse(JSON.parse(await res.text()))
 }

--- a/lib/github/schemas.ts
+++ b/lib/github/schemas.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod'
+
+// ---------------------------------------------------------------------------
+// GitHub API response schemas
+// ---------------------------------------------------------------------------
+// These schemas mirror the TypeScript interfaces in client.ts and provide
+// runtime validation of GitHub REST API responses.
+// ---------------------------------------------------------------------------
+
+export const GitHubRepoSchema = z.object({
+  full_name: z.string(),
+  name: z.string(),
+  owner: z.object({ login: z.string() }),
+  description: z.string().nullable(),
+  language: z.string().nullable(),
+  default_branch: z.string(),
+  stargazers_count: z.number(),
+  size: z.number(),
+  topics: z.array(z.string()).default([]),
+  open_issues_count: z.number(),
+  html_url: z.string(),
+})
+
+export const GitHubIssueRawSchema = z.object({
+  number: z.number(),
+  title: z.string(),
+  body: z.string().nullable(),
+  state: z.string(),
+  labels: z.array(z.object({ name: z.string() })),
+  created_at: z.string(),
+  updated_at: z.string(),
+  html_url: z.string(),
+})
+
+export const GitHubFileContentSchema = z.object({
+  content: z.string(),
+  encoding: z.string(),
+  size: z.number(),
+})
+
+export const GitHubPRSchema = z.object({
+  number: z.number(),
+  html_url: z.string(),
+  draft: z.boolean(),
+  state: z.string(),
+  user: z.object({ login: z.string() }),
+  body: z.string().nullable(),
+  head: z.object({ repo: z.object({ full_name: z.string() }) }),
+})
+
+export const GitHubRootTreeSchema = z.object({
+  tree: z.array(z.object({ path: z.string(), type: z.string() })),
+})
+
+export const GitHubLanguagesSchema = z.record(z.string(), z.number())

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,0 +1,66 @@
+{
+  "name": "tokenforgood",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tokenforgood",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "tokenforgood": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,12 +15,19 @@
     "dist",
     "README.md"
   ],
-  "keywords": ["tokenforgood", "open-source", "ai", "claude"],
+  "keywords": [
+    "tokenforgood",
+    "open-source",
+    "ai",
+    "claude"
+  ],
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
   "devDependencies": {
-    "typescript": "^5.0.0",
-    "@types/node": "^20.0.0"
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/cli/src/services/api.ts
+++ b/packages/cli/src/services/api.ts
@@ -1,10 +1,40 @@
+import { z } from 'zod'
+
 export const API_BASE = process.env.TOKENFORGOOD_API_URL ?? 'https://tokenforgood.dev'
+
+// ---------------------------------------------------------------------------
+// Response schemas
+// ---------------------------------------------------------------------------
+
+const TaskResponseSchema = z.object({
+  id: z.string(),
+  github_issue_url: z.string(),
+  github_issue_title: z.string(),
+  repo_full_name: z.string(),
+  task_type: z.string(),
+  template: z
+    .object({ name: z.string(), recommended_mode: z.string() })
+    .nullable(),
+})
+
+const ClaimResponseSchema = z.object({
+  claim_token: z.string(),
+})
+
+// ---------------------------------------------------------------------------
+// Types — derived from schemas to avoid duplication
+// ---------------------------------------------------------------------------
+
+export type TaskResponse = z.infer<typeof TaskResponseSchema>
+
+// ---------------------------------------------------------------------------
+// API functions
+// ---------------------------------------------------------------------------
 
 export async function fetchTask(taskId: string): Promise<TaskResponse> {
   const response = await fetch(`${API_BASE}/api/tasks/${taskId}`)
   if (!response.ok) throw new Error(`Task not found: ${taskId}`)
-  const data: TaskResponse = await response.json()
-  return data
+  return TaskResponseSchema.parse(await response.json())
 }
 
 export async function claimTask(taskId: string, githubToken?: string): Promise<{ claimToken: string }> {
@@ -17,7 +47,7 @@ export async function claimTask(taskId: string, githubToken?: string): Promise<{
     body: JSON.stringify({}),
   })
   if (!response.ok) throw new Error('Failed to claim task')
-  const data: { claim_token: string } = await response.json()
+  const data = ClaimResponseSchema.parse(await response.json())
   return { claimToken: data.claim_token }
 }
 
@@ -36,14 +66,4 @@ export function startHeartbeat(taskId: string, claimToken: string): NodeJS.Timeo
   return setInterval(() => {
     void sendHeartbeat(taskId, claimToken)
   }, 60_000) // every 60 seconds
-}
-
-// Types
-export interface TaskResponse {
-  id: string
-  github_issue_url: string
-  github_issue_title: string
-  repo_full_name: string
-  task_type: string
-  template: { name: string; recommended_mode: string } | null
 }


### PR DESCRIPTION
## Summary

- Add `lib/github/schemas.ts` with Zod schemas co-located near the types they validate (GitHubRepo, GitHubIssueRaw, GitHubFileContent, GitHubPR, GitHubRootTree, GitHubLanguages)
- Refactor `lib/github/client.ts` to derive `export type` aliases from schemas via `z.infer` (eliminates duplicate interface + schema definitions), and pass a schema to `githubFetchJson` so every response is validated at runtime
- Add `TaskResponseSchema` and `ClaimResponseSchema` inline in `packages/cli/src/services/api.ts`; replace all unsafe `response.json()` casts with `.parse()` calls
- Add `zod ^4.3.6` as a runtime dependency to the CLI package

All 397 tests pass. No `as T` assertions — complies with `assertionStyle: "never"` ESLint rule.

## Test plan

- [x] `npm test` — 397 tests pass
- [x] `npx tsc --noEmit` — zero errors in changed files
- [x] Schema `.parse()` will throw a `ZodError` with a descriptive message if the GitHub API or internal API returns an unexpected shape

Closes #8