### PR TITLE
refactor: consolidate StatusIndicator and StatusBadge into shared component

### DIFF
--- a/app/tasks/[id]/page.tsx
+++ b/app/tasks/[id]/page.tsx
@@ -4,9 +4,7 @@ import {
   ExternalLink,
   GitPullRequest,
   CheckCircle2,
-  Circle,
   Clock,
-  AlertTriangle,
   Star,
   Terminal,
   Cpu,
@@ -27,6 +25,7 @@ import { Separator } from '@/components/ui/separator'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { CopyButton } from './copy-button'
 import { HighlightedPrompt } from './highlighted-prompt'
+import { StatusIndicator } from '@/components/status-indicator'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -61,86 +60,6 @@ function modelBadgeColor(model: string): string {
     default:
       return 'bg-muted text-muted-foreground'
   }
-}
-
-// ---------------------------------------------------------------------------
-// Status badge
-// ---------------------------------------------------------------------------
-
-function StatusBadge({ task }: { task: Task }) {
-  const { status, claimed_by, last_heartbeat_at, claimed_at } = task
-
-  if (status === 'open') {
-    return (
-      <span className="flex items-center gap-1.5 text-sm text-emerald-500">
-        <span className="relative flex size-2.5">
-          <span className="absolute inline-flex size-full animate-pulse rounded-full bg-emerald-400 opacity-75" />
-          <span className="relative inline-flex size-2.5 rounded-full bg-emerald-500" />
-        </span>
-        Open
-      </span>
-    )
-  }
-
-  if (status === 'claimed') {
-    return (
-      <span className="flex items-center gap-1.5 text-sm text-amber-500">
-        <span className="relative inline-flex size-2.5 rounded-full bg-amber-400" />
-        {claimed_by ? `Claimed by @${claimed_by}` : 'Claimed'}
-      </span>
-    )
-  }
-
-  if (status === 'in_progress') {
-    const since = last_heartbeat_at ?? claimed_at
-    const ago = since
-      ? formatDistanceToNow(new Date(since), { addSuffix: false })
-      : null
-    return (
-      <span className="flex items-center gap-1.5 text-sm text-blue-500">
-        <span className="relative flex size-2.5">
-          <span className="absolute inline-flex size-full animate-pulse rounded-full bg-blue-400 opacity-75" />
-          <span className="relative inline-flex size-2.5 rounded-full bg-blue-500" />
-        </span>
-        {claimed_by ? `@${claimed_by}` : 'In progress'}
-        {ago ? ` · ${ago} ago` : ''}
-      </span>
-    )
-  }
-
-  if (status === 'completed') {
-    return (
-      <span className="flex items-center gap-1.5 text-sm text-emerald-500">
-        <CheckCircle2 className="size-4" />
-        Completed
-      </span>
-    )
-  }
-
-  if (status === 'stalled') {
-    return (
-      <span className="flex items-center gap-1.5 text-sm text-orange-500">
-        <AlertTriangle className="size-4" />
-        Stalled
-      </span>
-    )
-  }
-
-  if (status === 'failed') {
-    return (
-      <span className="flex items-center gap-1.5 text-sm text-destructive">
-        <Circle className="size-4" />
-        Failed
-      </span>
-    )
-  }
-
-  return (
-    <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
-      <Clock className="size-4" />
-      {status.charAt(0).toUpperCase() + status.slice(1)}
-    </span>
-  )
 }
 
 // ---------------------------------------------------------------------------
@@ -330,7 +249,14 @@ export default async function TaskPage({
             </Badge>
           )}
 
-          <StatusBadge task={task} />
+          <StatusIndicator
+            status={task.status}
+            size="md"
+            claimedBy={task.claimed_by}
+            lastHeartbeatAt={task.last_heartbeat_at}
+            claimedAt={task.claimed_at}
+            prUrl={task.pr_url}
+          />
 
           {task.tags.map((tag) => (
             <Badge key={tag} variant="secondary" className="text-xs">
@@ -674,7 +600,14 @@ export default async function TaskPage({
             </CardHeader>
             <Separator />
             <CardContent className="space-y-2 p-4">
-              <StatusBadge task={task} />
+              <StatusIndicator
+                status={task.status}
+                size="md"
+                claimedBy={task.claimed_by}
+                lastHeartbeatAt={task.last_heartbeat_at}
+                claimedAt={task.claimed_at}
+                prUrl={task.pr_url}
+              />
 
               {(task.status === 'claimed' || task.status === 'in_progress') &&
                 task.claimed_by && (

--- a/components/status-indicator.tsx
+++ b/components/status-indicator.tsx
@@ -1,0 +1,150 @@
+"use client"
+
+import { formatDistanceToNow } from "date-fns"
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Circle,
+  Clock,
+  ExternalLink,
+} from "lucide-react"
+
+import { type Task } from "@/lib/types"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface StatusIndicatorProps {
+  status: Task["status"]
+  /** 'sm' uses size-2 dot and text-xs (task card). 'md' uses size-2.5 dot and text-sm (detail page). */
+  size?: "sm" | "md"
+  /** Claimed-by GitHub username (without @). Used in claimed / in_progress / completed labels. */
+  claimedBy?: string | null
+  /** ISO timestamp used for the "X ago" label when in_progress. Falls back to claimedAt. */
+  lastHeartbeatAt?: string | null
+  /** ISO timestamp used as fallback for the "X ago" label when in_progress. */
+  claimedAt?: string | null
+  /** When provided and status is completed, renders a PR link instead of plain text. */
+  prUrl?: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Tailwind classes that vary by size. */
+function sizeClasses(size: "sm" | "md") {
+  return {
+    text: size === "sm" ? "text-xs" : "text-sm",
+    dot: size === "sm" ? "size-2" : "size-2.5",
+    icon: size === "sm" ? "size-3.5" : "size-4",
+  }
+}
+
+// ---------------------------------------------------------------------------
+// StatusIndicator
+// ---------------------------------------------------------------------------
+
+export function StatusIndicator({
+  status,
+  size = "sm",
+  claimedBy,
+  lastHeartbeatAt,
+  claimedAt,
+  prUrl,
+}: StatusIndicatorProps) {
+  const cls = sizeClasses(size)
+
+  if (status === "open") {
+    return (
+      <span className={`flex items-center gap-1.5 ${cls.text} text-emerald-500`}>
+        <span className={`relative flex ${cls.dot}`}>
+          <span className="absolute inline-flex size-full animate-pulse rounded-full bg-emerald-400 opacity-75" />
+          <span className={`relative inline-flex ${cls.dot} rounded-full bg-emerald-500`} />
+        </span>
+        Open
+      </span>
+    )
+  }
+
+  if (status === "claimed") {
+    return (
+      <span className={`flex items-center gap-1.5 ${cls.text} text-amber-500`}>
+        <span className={`relative inline-flex ${cls.dot} rounded-full bg-amber-400`} />
+        {claimedBy ? `Claimed by @${claimedBy}` : "Claimed"}
+      </span>
+    )
+  }
+
+  if (status === "in_progress") {
+    const since = lastHeartbeatAt ?? claimedAt
+    const ago = since
+      ? formatDistanceToNow(new Date(since), { addSuffix: false })
+      : null
+
+    return (
+      <span className={`flex items-center gap-1.5 ${cls.text} text-blue-500`}>
+        <span className={`relative flex ${cls.dot}`}>
+          <span className="absolute inline-flex size-full animate-pulse rounded-full bg-blue-400 opacity-75" />
+          <span className={`relative inline-flex ${cls.dot} rounded-full bg-blue-500`} />
+        </span>
+        {claimedBy ? `@${claimedBy}` : "In progress"}
+        {ago ? ` · ${ago} ago` : ""}
+      </span>
+    )
+  }
+
+  if (status === "completed") {
+    return (
+      <span className={`flex items-center gap-1.5 ${cls.text} text-muted-foreground`}>
+        <CheckCircle2 className={`${cls.icon} text-emerald-500`} />
+        {prUrl ? (
+          <a
+            href={prUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-0.5 hover:underline"
+          >
+            Resolved
+            {claimedBy ? ` by @${claimedBy}` : ""}
+            <ExternalLink className="size-2.5 opacity-60" />
+          </a>
+        ) : (
+          <span>
+            Completed{claimedBy ? ` by @${claimedBy}` : ""}
+          </span>
+        )}
+      </span>
+    )
+  }
+
+  if (status === "stalled") {
+    return (
+      <span className={`flex items-center gap-1.5 ${cls.text} text-orange-500`}>
+        <AlertTriangle className={cls.icon} />
+        Stalled
+      </span>
+    )
+  }
+
+  if (status === "failed") {
+    return (
+      <span className={`flex items-center gap-1.5 ${cls.text} text-destructive`}>
+        <Circle className={cls.icon} />
+        Failed
+      </span>
+    )
+  }
+
+  if (status === "expired" || status === "stale") {
+    return (
+      <span className={`flex items-center gap-1.5 ${cls.text} text-muted-foreground`}>
+        <Clock className={cls.icon} />
+        {status === "expired" ? "Expired" : "Stale"}
+      </span>
+    )
+  }
+
+  return null
+}

--- a/components/status-indicator.tsx
+++ b/components/status-indicator.tsx
@@ -8,6 +8,7 @@ import {
   Clock,
   ExternalLink,
 } from "lucide-react"
+import * as React from "react"
 
 import { type Task } from "@/lib/types"
 
@@ -56,6 +57,19 @@ export function StatusIndicator({
 }: StatusIndicatorProps) {
   const cls = sizeClasses(size)
 
+  // SSR-safe relative time: compute only after client mount to avoid hydration
+  // mismatch (Date.now() differs between server render and client hydration).
+  const since = lastHeartbeatAt ?? claimedAt
+  const [relativeTime, setRelativeTime] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    if (since) {
+      setRelativeTime(
+        formatDistanceToNow(new Date(since), { addSuffix: false })
+      )
+    }
+  }, [since])
+
   if (status === "open") {
     return (
       <span className={`flex items-center gap-1.5 ${cls.text} text-emerald-500`}>
@@ -78,10 +92,13 @@ export function StatusIndicator({
   }
 
   if (status === "in_progress") {
-    const since = lastHeartbeatAt ?? claimedAt
-    const ago = since
-      ? formatDistanceToNow(new Date(since), { addSuffix: false })
-      : null
+    // relativeTime is null on the server; falls back to a static locale date
+    // string on first render, then swaps to relative time after mount.
+    const agoDisplay = relativeTime
+      ? ` · ${relativeTime} ago`
+      : since
+        ? ` · ${new Date(since).toLocaleDateString()}`
+        : ""
 
     return (
       <span className={`flex items-center gap-1.5 ${cls.text} text-blue-500`}>
@@ -90,7 +107,7 @@ export function StatusIndicator({
           <span className={`relative inline-flex ${cls.dot} rounded-full bg-blue-500`} />
         </span>
         {claimedBy ? `@${claimedBy}` : "In progress"}
-        {ago ? ` · ${ago} ago` : ""}
+        {agoDisplay}
       </span>
     )
   }

--- a/components/task-card.tsx
+++ b/components/task-card.tsx
@@ -1,12 +1,6 @@
 "use client"
 
-import { formatDistanceToNow } from "date-fns"
 import {
-  CheckCircle2,
-  Circle,
-  Clock,
-  AlertTriangle,
-  ExternalLink,
   PlayCircle,
   Cpu,
 } from "lucide-react"
@@ -22,108 +16,7 @@ import {
   CardHeader,
 } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
-
-// ---------------------------------------------------------------------------
-// Status indicator
-// ---------------------------------------------------------------------------
-
-function StatusIndicator({ task }: { task: Task }) {
-  const { status, claimed_by, last_heartbeat_at, claimed_at, pr_url } = task
-
-  if (status === "open") {
-    return (
-      <span className="flex items-center gap-1.5 text-xs text-emerald-500">
-        <span className="relative flex size-2">
-          <span className="absolute inline-flex size-full animate-pulse rounded-full bg-emerald-400 opacity-75" />
-          <span className="relative inline-flex size-2 rounded-full bg-emerald-500" />
-        </span>
-        Open
-      </span>
-    )
-  }
-
-  if (status === "claimed") {
-    return (
-      <span className="flex items-center gap-1.5 text-xs text-amber-500">
-        <span className="relative flex size-2">
-          <span className="relative inline-flex size-2 rounded-full bg-amber-400" />
-        </span>
-        {claimed_by ? `Claimed by @${claimed_by}` : "Claimed"}
-      </span>
-    )
-  }
-
-  if (status === "in_progress") {
-    const since = last_heartbeat_at ?? claimed_at
-    const ago = since
-      ? formatDistanceToNow(new Date(since), { addSuffix: false })
-      : null
-
-    return (
-      <span className="flex items-center gap-1.5 text-xs text-blue-500">
-        <span className="relative flex size-2">
-          <span className="absolute inline-flex size-full animate-pulse rounded-full bg-blue-400 opacity-75" />
-          <span className="relative inline-flex size-2 rounded-full bg-blue-500" />
-        </span>
-        {claimed_by ? `@${claimed_by}` : "In progress"}
-        {ago ? ` · ${ago} ago` : ""}
-      </span>
-    )
-  }
-
-  if (status === "completed") {
-    return (
-      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-        <CheckCircle2 className="size-3.5 text-emerald-500" />
-        {pr_url ? (
-          <a
-            href={pr_url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-0.5 hover:underline"
-          >
-            Resolved
-            {claimed_by ? ` by @${claimed_by}` : ""}
-            <ExternalLink className="size-2.5 opacity-60" />
-          </a>
-        ) : (
-          <span>
-            Completed{claimed_by ? ` by @${claimed_by}` : ""}
-          </span>
-        )}
-      </span>
-    )
-  }
-
-  if (status === "stalled") {
-    return (
-      <span className="flex items-center gap-1.5 text-xs text-orange-500">
-        <AlertTriangle className="size-3.5" />
-        Stalled
-      </span>
-    )
-  }
-
-  if (status === "failed") {
-    return (
-      <span className="flex items-center gap-1.5 text-xs text-destructive">
-        <Circle className="size-3.5" />
-        Failed
-      </span>
-    )
-  }
-
-  if (status === "expired" || status === "stale") {
-    return (
-      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-        <Clock className="size-3.5" />
-        {status === "expired" ? "Expired" : "Stale"}
-      </span>
-    )
-  }
-
-  return null
-}
+import { StatusIndicator } from "@/components/status-indicator"
 
 // ---------------------------------------------------------------------------
 // Token estimate label
@@ -229,7 +122,14 @@ export function TaskCard({
               )}
             </span>
             {(showCompletedBy || task.status !== "completed") && (
-              <StatusIndicator task={task} />
+              <StatusIndicator
+                status={task.status}
+                size="sm"
+                claimedBy={task.claimed_by}
+                lastHeartbeatAt={task.last_heartbeat_at}
+                claimedAt={task.claimed_at}
+                prUrl={task.pr_url}
+              />
             )}
           </div>
 


### PR DESCRIPTION
## Summary

- Extracts the duplicated `StatusIndicator` (task-card.tsx) and `StatusBadge` (app/tasks/[id]/page.tsx) into a single shared `StatusIndicator` component at `components/status-indicator.tsx`
- Uses a `size` prop (`'sm' | 'md'`) to handle the dot/text/icon size differences between card and detail page contexts
- Accepts individual props (`claimedBy`, `lastHeartbeatAt`, `claimedAt`, `prUrl`) rather than the full `Task` object for better reusability
- The `prUrl` prop enables the PR link rendering in the completed state (previously only in the card version)
- No `as X` casts — fully compliant with `assertionStyle: never` ESLint rule

## Test plan

- [x] `npm run build` — zero errors (pre-existing `request-task-modal.tsx` type error is unrelated and present on main)
- [x] `npm test` — 230/230 tests passing
- [x] Both call sites updated: task-card uses `size="sm"`, detail page uses `size="md"`

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)